### PR TITLE
Add application key in Azure Open Ai LLM's model.

### DIFF
--- a/package.json
+++ b/package.json
@@ -117,5 +117,8 @@
       "element-plus@2.4.3": "patches/element-plus@2.4.3.patch",
       "js-base64": "patches/js-base64.patch"
     }
+  },
+  "dependencies": {
+    "async-mutex": "^0.5.0"
   }
 }

--- a/packages/@n8n/nodes-langchain/credentials/AzureOpenAiClientApi.credentials.ts
+++ b/packages/@n8n/nodes-langchain/credentials/AzureOpenAiClientApi.credentials.ts
@@ -1,0 +1,56 @@
+import type { IAuthenticateGeneric, ICredentialType, INodeProperties } from 'n8n-workflow';
+
+export class AzureOpenAiClientApi implements ICredentialType {
+	name = 'azureOpenAiClientApi';
+
+	displayName = 'Azure Open AI Client Credentials';
+
+	documentationUrl = 'azureopenai';
+
+	properties: INodeProperties[] = [
+		{
+			displayName: 'Client Id',
+			name: 'clientId',
+			type: 'string',
+			required: true,
+			default: '',
+		},
+		{
+			displayName: 'Client Secret',
+			name: 'clientSecret',
+			type: 'string',
+			typeOptions: { password: true },
+			required: true,
+			default: '',
+		},
+		{
+			displayName: 'Resource Name',
+			name: 'resourceName',
+			type: 'string',
+			default: '',
+		},
+		{
+			displayName: 'API Version',
+			name: 'apiVersion',
+			type: 'string',
+			required: true,
+			default: '2024-12-01-preview',
+		},
+		{
+			displayName: 'Endpoint',
+			name: 'endpoint',
+			type: 'string',
+			default: 'https://chat-ai.cisco.com',
+			placeholder: 'https://chat-ai.cisco.com',
+		},
+	];
+
+	authenticate: IAuthenticateGeneric = {
+		type: 'generic',
+		properties: {
+			headers: {
+				'api-key': '={{$credentials.apiKey}}',
+			},
+		},
+	};
+}

--- a/packages/@n8n/nodes-langchain/nodes/llms/LmChatAzureOpenAi/credentials/api-key.ts
+++ b/packages/@n8n/nodes-langchain/nodes/llms/LmChatAzureOpenAi/credentials/api-key.ts
@@ -1,7 +1,10 @@
 import { NodeOperationError, OperationalError, type ISupplyDataFunctions } from 'n8n-workflow';
 
+import { ClientTokenManager } from '../../../../utils/ClientTokenManager';
 import type { AzureOpenAIApiKeyModelConfig } from '../types';
 
+export const authUrl = 'https://id.cisco.com/oauth2/default/v1/token';
+const clientTokenManager = new ClientTokenManager();
 /**
  * Handles API Key authentication setup for Azure OpenAI
  */
@@ -29,6 +32,117 @@ export async function setupApiKeyAuthentication(
 
 		return {
 			azureOpenAIApiKey: configCredentials.apiKey,
+			azureOpenAIApiInstanceName: configCredentials.resourceName,
+			azureOpenAIApiVersion: configCredentials.apiVersion,
+			azureOpenAIEndpoint: configCredentials.endpoint,
+		};
+	} catch (error) {
+		if (error instanceof OperationalError) {
+			throw error;
+		}
+
+		this.logger.error(`Error setting up API Key authentication: ${error.message}`, error);
+
+		throw new NodeOperationError(this.getNode(), 'Failed to retrieve API Key', error);
+	}
+}
+
+interface FetchApiKeyResponse {
+	error: Error | null;
+	token: string;
+}
+
+// Define a function to fetch the API key
+async function fetchApiKey(clientId: string, clientSecret: string): Promise<FetchApiKeyResponse> {
+	try {
+		// Check if the client token is already cached
+		const hasToken = await clientTokenManager.hasToken(clientId);
+		if (hasToken) {
+			// Return the cached token
+			const cachedToken = await clientTokenManager.getToken(clientId);
+			if (cachedToken) {
+				console.log('Using cached access token:', cachedToken);
+				return { error: null, token: cachedToken };
+			}
+		}
+		// If not cached, make a request to fetch the API key
+		const response = await fetch(authUrl, {
+			method: 'POST',
+			headers: {
+				'Content-Type': 'application/x-www-form-urlencoded',
+			},
+			body: new URLSearchParams({
+				client_id: clientId,
+				client_secret: clientSecret,
+				grant_type: 'client_credentials', // Typically used grant type for machine-to-machine authentication
+			}).toString(),
+		});
+
+		if (!response.ok) {
+			console.error(`Error in fetching API key: ${response.statusText}`);
+			return {
+				error: new Error(`Error in fetching API key: ${response.statusText}`),
+				token: '',
+			};
+		}
+
+		// Parse the response
+		const data = await response.json();
+		// @ts-ignore
+		console.log('Access Token:', data.access_token);
+
+		// Cache the access token
+		// @ts-ignore
+		await clientTokenManager.storeToken(clientId, data.access_token);
+		// Return the access token (or API key)
+		// @ts-ignore
+		return { error: null, token: data.access_token };
+	} catch (error) {
+		console.error(error);
+		return {
+			error: new Error(`Failed to fetch API key: ${error.message}`),
+			token: '',
+		};
+	}
+}
+
+export async function setupClientApiKeyAuthentication(
+	this: ISupplyDataFunctions,
+	credentialName: string,
+): Promise<AzureOpenAIApiKeyModelConfig> {
+	try {
+		// Get Azure OpenAI Config (Endpoint, Version, etc.)
+		const configCredentials = await this.getCredentials<{
+			clientId?: string;
+			clientSecret?: string;
+			resourceName: string;
+			apiVersion: string;
+			endpoint?: string;
+		}>(credentialName);
+
+		if (!configCredentials.clientId || !configCredentials.clientSecret) {
+			throw new NodeOperationError(
+				this.getNode(),
+				'Client Id or Client Secret is missing in the selected Azure OpenAI' +
+					' API credential. Please configure the API Key or choose Client ' +
+					' authentication.',
+			);
+		}
+		const fetchResponse = await fetchApiKey(
+			configCredentials.clientId,
+			configCredentials.clientSecret,
+		);
+		if (fetchResponse.error) {
+			throw new NodeOperationError(
+				this.getNode(),
+				`Failed to fetch API Key: ${fetchResponse.error}`,
+			);
+		}
+
+		this.logger.info('Using Client Id and Secret authentication for Azure OpenAI.');
+
+		return {
+			azureOpenAIApiKey: fetchResponse.token,
 			azureOpenAIApiInstanceName: configCredentials.resourceName,
 			azureOpenAIApiVersion: configCredentials.apiVersion,
 			azureOpenAIEndpoint: configCredentials.endpoint,

--- a/packages/@n8n/nodes-langchain/nodes/llms/LmChatAzureOpenAi/properties.ts
+++ b/packages/@n8n/nodes-langchain/nodes/llms/LmChatAzureOpenAi/properties.ts
@@ -11,7 +11,7 @@ export const properties: INodeProperties[] = [
 		displayName: 'Authentication',
 		name: 'authentication',
 		type: 'options',
-		default: AuthenticationType.ApiKey,
+		default: AuthenticationType.ClientApi,
 		options: [
 			{
 				name: 'API Key',
@@ -20,6 +20,10 @@ export const properties: INodeProperties[] = [
 			{
 				name: 'Azure Entra ID (OAuth2)',
 				value: AuthenticationType.EntraOAuth2,
+			},
+			{
+				name: 'Client API Key',
+				value: AuthenticationType.ClientApi,
 			},
 		],
 	},
@@ -37,12 +41,20 @@ export const properties: INodeProperties[] = [
 		},
 	},
 	{
-		displayName: 'Model (Deployment) Name',
+		displayName: 'AI Model (Deployment) Name',
 		name: 'model',
 		type: 'string',
 		description: 'The name of the model(deployment) to use (e.g., gpt-4, gpt-35-turbo)',
 		required: true,
 		default: '',
+	},
+	{
+		displayName: 'Application Key',
+		name: 'appKey',
+		type: 'string',
+		default: '',
+		description:
+			'The application key to identify the application. This will be used as json object in request headers.',
 	},
 	{
 		displayName: 'Options',

--- a/packages/@n8n/nodes-langchain/nodes/llms/LmChatAzureOpenAi/types.ts
+++ b/packages/@n8n/nodes-langchain/nodes/llms/LmChatAzureOpenAi/types.ts
@@ -62,6 +62,7 @@ export interface AzureOpenAIOAuth2ModelConfig extends AzureOpenAIBaseModelConfig
  * Authentication types supported by Azure OpenAI node
  */
 export const enum AuthenticationType {
+	ClientApi = 'azureOpenAiClientApi',
 	ApiKey = 'azureOpenAiApi',
 	EntraOAuth2 = 'azureEntraCognitiveServicesOAuth2Api',
 }

--- a/packages/@n8n/nodes-langchain/package.json
+++ b/packages/@n8n/nodes-langchain/package.json
@@ -26,6 +26,7 @@
     "credentials": [
       "dist/credentials/AnthropicApi.credentials.js",
       "dist/credentials/AzureOpenAiApi.credentials.js",
+      "dist/credentials/AzureOpenAiClientApi.credentials.js",
       "dist/credentials/AzureEntraCognitiveServicesOAuth2Api.credentials.js",
       "dist/credentials/CohereApi.credentials.js",
       "dist/credentials/DeepSeekApi.credentials.js",

--- a/packages/@n8n/nodes-langchain/utils/ClientTokenManager.ts
+++ b/packages/@n8n/nodes-langchain/utils/ClientTokenManager.ts
@@ -1,0 +1,111 @@
+import { Mutex } from 'async-mutex';
+
+export class ClientTokenManager {
+	// Map to store client ID to access token mappings
+	private tokenMap: Map<string, string> = new Map<string, string>();
+	private mutex = new Mutex();
+
+	/**
+	 * Store an access token for a client ID
+	 * @param clientId the client identifier
+	 * @param accessToken the JWT token to store
+	 */
+	public async storeToken(clientId: string, accessToken: string): Promise<void> {
+		const release = await this.mutex.acquire();
+		try {
+			this.tokenMap.set(clientId, accessToken);
+		} finally {
+			release();
+		}
+	}
+
+	/**
+	 * Retrieve an access token for a client ID
+	 * @param clientId the client identifier
+	 * @return the stored access token, or undefined if not found
+	 */
+	public async getToken(clientId: string): Promise<string | undefined> {
+		const release = await this.mutex.acquire();
+		try {
+			return this.tokenMap.get(clientId);
+		} finally {
+			release();
+		}
+	}
+
+	/**
+	 * Check if a valid token exists for a client
+	 * If the token has expired or will expire in next 2 minutes, removes it and returns false
+	 */
+	public async hasToken(clientId: string): Promise<boolean> {
+		const release = await this.mutex.acquire();
+		try {
+			const token = this.tokenMap.get(clientId);
+			if (!token) {
+				return false;
+			}
+
+			const expTime = this.parseTokenExpiration(token);
+			const twoMinutesInMs = 2 * 60 * 1000;
+
+			// Check if token is expired or will expire in next 2 minutes
+			if (
+				expTime &&
+				(Date.now() >= expTime * 1000 || expTime * 1000 - Date.now() < twoMinutesInMs)
+			) {
+				// Token has expired or will expire soon, remove it
+				console.log(
+					'Token for client ' + clientId + ' has expired or will' + ' expire soon, removing it.',
+				);
+				this.tokenMap.delete(clientId);
+				return false;
+			}
+
+			return true;
+		} finally {
+			release();
+		}
+	}
+
+	/**
+	 * Remove a token
+	 */
+	public async removeToken(clientId: string): Promise<string | undefined> {
+		const release = await this.mutex.acquire();
+		try {
+			const token = this.tokenMap.get(clientId);
+			this.tokenMap.delete(clientId);
+			return token;
+		} finally {
+			release();
+		}
+	}
+
+	/**
+	 * Parse JWT token and extract the expiration time
+	 * @param token JWT token to parse
+	 * @returns the expiration timestamp or undefined if parsing failed
+	 */
+	private parseTokenExpiration(token: string): number | undefined {
+		try {
+			// JWT format: header.payload.signature
+			const parts = token.split('.');
+			if (parts.length !== 3) return undefined;
+
+			// Decode base64url-encoded payload
+			const base64 = parts[1].replace(/-/g, '+').replace(/_/g, '/');
+
+			// Add padding if needed
+			const pad = base64.length % 4;
+			const paddedBase64 = pad ? base64 + '='.repeat(4 - pad) : base64;
+
+			// Parse the payload
+			const payload = JSON.parse(Buffer.from(paddedBase64, 'base64').toString('utf8'));
+
+			return payload.exp;
+		} catch (error) {
+			console.error('Error parsing JWT token:', error);
+			return undefined;
+		}
+	}
+}


### PR DESCRIPTION
### Summary:


For enterprise Azure Open AII LLM's application key is mandatory for authorization.

- Updated `LmChatAzureOpenAi.node.ts` to include the ability to pass the application key through headers for user authorization.
- Addresses the issue where LLM returns a 422 error if the application key is not provided in enterprise Azure Open AI LLM's.

This change is necessary to enable proper authorization when interacting with Azure OpenAI models.

